### PR TITLE
퀴즈 데이터 제공 및 정답 비교 API 구현

### DIFF
--- a/src/main/java/hyu/dayPocket/config/CustomUserDetails.java
+++ b/src/main/java/hyu/dayPocket/config/CustomUserDetails.java
@@ -1,6 +1,7 @@
 package hyu.dayPocket.config;
 
 import hyu.dayPocket.domain.Member;
+import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -9,6 +10,7 @@ import java.util.Collection;
 import java.util.List;
 
 public class CustomUserDetails implements UserDetails {
+    @Getter
     private final Member member;
     private final List<GrantedAuthority> authorities;
 

--- a/src/main/java/hyu/dayPocket/controller/QuizController.java
+++ b/src/main/java/hyu/dayPocket/controller/QuizController.java
@@ -1,9 +1,15 @@
 package hyu.dayPocket.controller;
 
+import hyu.dayPocket.config.CustomUserDetails;
+import hyu.dayPocket.dto.MemberChosenAnswer;
 import hyu.dayPocket.dto.QuizProvidingDto;
 import hyu.dayPocket.service.QuizService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -18,5 +24,8 @@ public class QuizController {
         return quizService.provideQuiz();
     }
 
-
+    @PostMapping("/submit/quiz")
+    public int checkClientAnswer(@RequestBody List<MemberChosenAnswer> dto, @AuthenticationPrincipal CustomUserDetails userDetails) {
+        return quizService.checkIfCorrectAnswers(dto, userDetails.getMember());
+    }
 }

--- a/src/main/java/hyu/dayPocket/controller/QuizController.java
+++ b/src/main/java/hyu/dayPocket/controller/QuizController.java
@@ -1,0 +1,22 @@
+package hyu.dayPocket.controller;
+
+import hyu.dayPocket.dto.QuizProvidingDto;
+import hyu.dayPocket.service.QuizService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class QuizController {
+    private final QuizService quizService;
+
+    @GetMapping("/quiz-list")
+    public List<QuizProvidingDto> getQuizList() {
+        return quizService.provideQuiz();
+    }
+
+
+}

--- a/src/main/java/hyu/dayPocket/domain/Member.java
+++ b/src/main/java/hyu/dayPocket/domain/Member.java
@@ -25,6 +25,7 @@ public class Member {
 
     private Long fiScore;
 
+    @Setter
     private Integer fiPoint;
 
     private Long asset;

--- a/src/main/java/hyu/dayPocket/domain/Quiz.java
+++ b/src/main/java/hyu/dayPocket/domain/Quiz.java
@@ -17,7 +17,5 @@ public class Quiz {
     @ManyToOne
     @JoinColumn(name = "memberChallenge_id")
     private MemberChallenge memberChallenge;
-
-
 }
 

--- a/src/main/java/hyu/dayPocket/dto/MemberChosenAnswer.java
+++ b/src/main/java/hyu/dayPocket/dto/MemberChosenAnswer.java
@@ -1,0 +1,11 @@
+package hyu.dayPocket.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MemberChosenAnswer {
+    private Long id;
+    private Boolean answer;
+}

--- a/src/main/java/hyu/dayPocket/dto/QuizProvidingDto.java
+++ b/src/main/java/hyu/dayPocket/dto/QuizProvidingDto.java
@@ -1,0 +1,9 @@
+package hyu.dayPocket.dto;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public class QuizProvidingDto {
+    private Long id;
+    private String question;
+}

--- a/src/main/java/hyu/dayPocket/repository/QuizRepository.java
+++ b/src/main/java/hyu/dayPocket/repository/QuizRepository.java
@@ -1,6 +1,7 @@
 package hyu.dayPocket.repository;
 
 import hyu.dayPocket.domain.Quiz;
+import hyu.dayPocket.dto.MemberChosenAnswer;
 import hyu.dayPocket.dto.QuizProvidingDto;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -17,4 +18,7 @@ public interface QuizRepository extends JpaRepository<Quiz, Long> {
             "FROM Quiz q WHERE q.id IN :ids")
     List<QuizProvidingDto> findAllByInIdSet(@Param("ids") Set<Long> ids);
 
+    @Query("SELECT new hyu.dayPocket.dto.MemberChosenAnswer(q.id, q.answer) " +
+            "FROM Quiz q WHERE q.id IN :ids")
+    List<MemberChosenAnswer> findAllAnswerByInIdSet(@Param("ids") Set<Long> ids);
 }

--- a/src/main/java/hyu/dayPocket/repository/QuizRepository.java
+++ b/src/main/java/hyu/dayPocket/repository/QuizRepository.java
@@ -1,0 +1,20 @@
+package hyu.dayPocket.repository;
+
+import hyu.dayPocket.domain.Quiz;
+import hyu.dayPocket.dto.QuizProvidingDto;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Set;
+
+public interface QuizRepository extends JpaRepository<Quiz, Long> {
+    @Query("SELECT MAX(q.id) FROM Quiz q")
+    Long findMaxId();
+
+    @Query("SELECT new hyu.dayPocket.dto.QuizProvidingDto(q.id, q.question) " +
+            "FROM Quiz q WHERE q.id IN :ids")
+    List<QuizProvidingDto> findAllByInIdSet(@Param("ids") Set<Long> ids);
+
+}

--- a/src/main/java/hyu/dayPocket/service/QuizService.java
+++ b/src/main/java/hyu/dayPocket/service/QuizService.java
@@ -1,0 +1,32 @@
+package hyu.dayPocket.service;
+
+import hyu.dayPocket.dto.QuizProvidingDto;
+import hyu.dayPocket.repository.QuizRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+
+@Service
+@Transactional(readOnly=true)
+@RequiredArgsConstructor
+public class QuizService {
+    private final QuizRepository quizRepository;
+
+    public List<QuizProvidingDto> provideQuiz() {
+        Long maxId = quizRepository.findMaxId();
+        Set<Long> randomIds = new HashSet<>();
+        Random random = new Random();
+
+        while (randomIds.size() < 5) {
+            long randomId = 1 + random.nextLong(maxId);
+            randomIds.add(randomId);
+        }
+
+        return quizRepository.findAllByInIdSet(randomIds);
+    }
+}

--- a/src/main/java/hyu/dayPocket/service/QuizService.java
+++ b/src/main/java/hyu/dayPocket/service/QuizService.java
@@ -1,21 +1,22 @@
 package hyu.dayPocket.service;
 
+import hyu.dayPocket.domain.Member;
+import hyu.dayPocket.dto.MemberChosenAnswer;
 import hyu.dayPocket.dto.QuizProvidingDto;
 import hyu.dayPocket.repository.QuizRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Random;
-import java.util.Set;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly=true)
 @RequiredArgsConstructor
 public class QuizService {
     private final QuizRepository quizRepository;
+    private final MemberService memberService;
 
     public List<QuizProvidingDto> provideQuiz() {
         Long maxId = quizRepository.findMaxId();
@@ -28,5 +29,23 @@ public class QuizService {
         }
 
         return quizRepository.findAllByInIdSet(randomIds);
+    }
+
+    @Transactional
+    public int checkIfCorrectAnswers(List<MemberChosenAnswer> memberChosenAnswers, Member member) {
+        Set<Long> ids = memberChosenAnswers.stream()
+                .map(MemberChosenAnswer::getId)
+                .collect(Collectors.toSet());
+
+        Map<Long, Boolean> correctAnswerMap = quizRepository.findAllAnswerByInIdSet(ids).stream()
+                .collect(Collectors.toMap(MemberChosenAnswer::getId, MemberChosenAnswer::getAnswer));
+
+        int correctAnswerCount = (int )memberChosenAnswers.stream()
+                .filter(answer -> correctAnswerMap.containsKey(answer.getId()) &&
+                        correctAnswerMap.get(answer.getId()).equals(answer.getAnswer()))
+                .count();
+
+        member.setFiPoint(member.getFiPoint() - 50 * correctAnswerCount);
+        return correctAnswerCount;
     }
 }


### PR DESCRIPTION
## 📌 퀴즈 데이터 제공 및 정답 비교 API 구현


---

## 📝 변경사항
- 퀴즈 DB id의 최댓값 이하의 랜덤 id 5개로 퀴즈 산정하는 방식의 퀴즈 제공 API
- 프론트와 퀴즈 데이터의 id를 가지고 정답 비교 하는 API 추가

---

## 🔍 테스트 방법
- 테스트 코드 추가할 예정입니다

---

## 💬 기타 참고사항