### PR TITLE
fiScore 초기설정 & 챌린지 수행시 fiPoint 및 fiScore를 업데이트

### DIFF
--- a/src/main/java/hyu/dayPocket/config/SecurityConfig.java
+++ b/src/main/java/hyu/dayPocket/config/SecurityConfig.java
@@ -8,12 +8,15 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.util.List;
 
 
 @Configuration
@@ -22,9 +25,10 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig  {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
-    public static final String[] WHITELIST = {
-            "/error"
-    };
+    public static final List<RestfulUrl> WHITELIST = List.of(
+            new RestfulUrl(HttpMethod.GET, "/admin/fiPointForm"),
+            new RestfulUrl(HttpMethod.POST, "/admin/fiPointForm")
+    );
 
     @Bean
     SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {

--- a/src/main/java/hyu/dayPocket/controller/FiPointController.java
+++ b/src/main/java/hyu/dayPocket/controller/FiPointController.java
@@ -2,17 +2,20 @@ package hyu.dayPocket.controller;
 
 import hyu.dayPocket.config.CustomUserDetails;
 import hyu.dayPocket.dto.PhotoRequestDto;
+import hyu.dayPocket.dto.StatusDto;
+import hyu.dayPocket.enums.ChallengeType;
+import hyu.dayPocket.enums.PointPaymentState;
 import hyu.dayPocket.repository.MemberRepository;
 import hyu.dayPocket.service.FiPointService;
 import lombok.RequiredArgsConstructor;
+import org.apache.coyote.Response;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.*;
 
-@Controller
+@RestController
 @RequiredArgsConstructor
 public class FiPointController {
 
@@ -27,8 +30,16 @@ public class FiPointController {
 
     @PostMapping("/admin/fiPointForm")
     public String updateFiPoint(@ModelAttribute PhotoRequestDto photoRequestDto){
-        fiPointService.addFiPoint(photoRequestDto);
+        fiPointService.updateFiPoint(photoRequestDto);
         return "redirect:/admin/fiPointForm";
     }
+
+    @GetMapping("/dayPocket/challenge/status")
+    public ResponseEntity<StatusDto> getLatestStatus ( @AuthenticationPrincipal CustomUserDetails userDetails,
+                                                       @RequestParam ChallengeType type){
+        StatusDto status = fiPointService.statusDto(userDetails.getMember(), type);
+        return ResponseEntity.ok(status);
+    }
+
 
 }

--- a/src/main/java/hyu/dayPocket/controller/FiPointController.java
+++ b/src/main/java/hyu/dayPocket/controller/FiPointController.java
@@ -1,0 +1,34 @@
+package hyu.dayPocket.controller;
+
+import hyu.dayPocket.config.CustomUserDetails;
+import hyu.dayPocket.dto.PhotoRequestDto;
+import hyu.dayPocket.repository.MemberRepository;
+import hyu.dayPocket.service.FiPointService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+
+@Controller
+@RequiredArgsConstructor
+public class FiPointController {
+
+    private final FiPointService fiPointService;
+    private final MemberRepository memberRepository;
+
+    @GetMapping
+    public String showAdminForm(Model model){
+        model.addAttribute("members", memberRepository.findAll() );
+        return "admin/fiPointForm";
+    }
+
+    @PostMapping("/admin/fiPointForm")
+    public String updateFiPoint(@ModelAttribute PhotoRequestDto photoRequestDto){
+        fiPointService.addFiPoint(photoRequestDto);
+        return "redirect:/admin/fiPointForm";
+    }
+
+}

--- a/src/main/java/hyu/dayPocket/domain/FiPointHistory.java
+++ b/src/main/java/hyu/dayPocket/domain/FiPointHistory.java
@@ -18,4 +18,12 @@ public class FiPointHistory {
     private Integer fiPoint;
 
     private LocalDateTime date;
+
+    public static FiPointHistory fiPointHistoryFrom(Member member, Integer fiPoint, LocalDateTime date) {
+        FiPointHistory fiPointHistory = new FiPointHistory();
+        fiPointHistory.member = member;
+        fiPointHistory.fiPoint = fiPoint;
+        fiPointHistory.date = date;
+        return fiPointHistory;
+    }
 }

--- a/src/main/java/hyu/dayPocket/domain/FiPointHistory.java
+++ b/src/main/java/hyu/dayPocket/domain/FiPointHistory.java
@@ -1,10 +1,14 @@
 package hyu.dayPocket.domain;
 
+import hyu.dayPocket.enums.ChallengeType;
+import hyu.dayPocket.enums.PointPaymentState;
 import jakarta.persistence.*;
+import lombok.Getter;
 
 import java.time.LocalDateTime;
 
 @Entity
+@Getter
 public class FiPointHistory {
 
     @Id
@@ -17,13 +21,32 @@ public class FiPointHistory {
 
     private Integer fiPoint;
 
+    @Enumerated(EnumType.STRING)
+    private ChallengeType challenge;
+
+    @Enumerated(EnumType.STRING)
+    private PointPaymentState state;
+
     private LocalDateTime date;
 
-    public static FiPointHistory fiPointHistoryFrom(Member member, Integer fiPoint, LocalDateTime date) {
+    public static FiPointHistory fiPointHistoryFrom(Member member, Integer fiPoint, PointPaymentState state, ChallengeType challenge, LocalDateTime date) {
         FiPointHistory fiPointHistory = new FiPointHistory();
         fiPointHistory.member = member;
         fiPointHistory.fiPoint = fiPoint;
+        fiPointHistory.state = state;
+        fiPointHistory.challenge = challenge;
         fiPointHistory.date = date;
         return fiPointHistory;
     }
+
+    public void updateStateRejected(){
+        state = PointPaymentState.REJECTED;
+    }
+
+    public void updateFiPontHistory(Integer point , LocalDateTime date){
+        state = PointPaymentState.APPROVED;
+        this.fiPoint = point;
+        this.date = date;
+    }
+
 }

--- a/src/main/java/hyu/dayPocket/domain/Member.java
+++ b/src/main/java/hyu/dayPocket/domain/Member.java
@@ -23,6 +23,7 @@ public class Member {
     @Column(unique = true)
     private String phoneNumber;
 
+    @Setter
     private Long fiScore;
 
     @Setter

--- a/src/main/java/hyu/dayPocket/domain/Receipt.java
+++ b/src/main/java/hyu/dayPocket/domain/Receipt.java
@@ -10,15 +10,23 @@ public class Receipt {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long receiptId;
 
-    private String business;
+    private String location;
 
-    private Integer spentMoney;
+    private String receiptItem;
 
-    private LocalDateTime spentTime;
+    private Integer price;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "memberChallenge_id")
     private MemberChallenge memberChallenge;
+
+    public static Receipt receiptFrom(String location, String receiptItem, Integer price){
+        Receipt receipt = new Receipt();
+        receipt.location = location;
+        receipt.receiptItem = receiptItem;
+        receipt.price = price;
+        return receipt;
+    }
 
 
 }

--- a/src/main/java/hyu/dayPocket/domain/Trade.java
+++ b/src/main/java/hyu/dayPocket/domain/Trade.java
@@ -2,13 +2,26 @@ package hyu.dayPocket.domain;
 
 import jakarta.persistence.*;
 
+import java.time.LocalDateTime;
+
 @Entity
 public class Trade {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    private Integer spentMoney;
+
+    private String tradeItem;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "memberChallenge_id")
     private MemberChallenge memberChallenge;
+
+    public static Trade tradeFrom(Integer spentMoney, String tradeItem){
+        Trade trade = new Trade();
+        trade.spentMoney = spentMoney;
+        trade.tradeItem = tradeItem;
+        return trade;
+    }
 }

--- a/src/main/java/hyu/dayPocket/dto/PhotoRequestDto.java
+++ b/src/main/java/hyu/dayPocket/dto/PhotoRequestDto.java
@@ -1,16 +1,19 @@
 package hyu.dayPocket.dto;
 
+import hyu.dayPocket.enums.ChallengeType;
+import hyu.dayPocket.enums.PointPaymentState;
 import lombok.Data;
 import org.springframework.format.annotation.DateTimeFormat;
 
 @Data
 public class PhotoRequestDto {
 
-    private String type;
+    private ChallengeType type;
     private Long memberId;
     private String itemName;
     private String location;
     private Integer amount;
+    private PointPaymentState state;
 
 
 }

--- a/src/main/java/hyu/dayPocket/dto/PhotoRequestDto.java
+++ b/src/main/java/hyu/dayPocket/dto/PhotoRequestDto.java
@@ -1,0 +1,16 @@
+package hyu.dayPocket.dto;
+
+import lombok.Data;
+import org.springframework.format.annotation.DateTimeFormat;
+
+@Data
+public class PhotoRequestDto {
+
+    private String type;
+    private Long memberId;
+    private String itemName;
+    private String location;
+    private Integer amount;
+
+
+}

--- a/src/main/java/hyu/dayPocket/dto/StatusDto.java
+++ b/src/main/java/hyu/dayPocket/dto/StatusDto.java
@@ -1,0 +1,13 @@
+package hyu.dayPocket.dto;
+
+import hyu.dayPocket.enums.PointPaymentState;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class StatusDto {
+
+    PointPaymentState state;
+
+}

--- a/src/main/java/hyu/dayPocket/enums/ChallengeType.java
+++ b/src/main/java/hyu/dayPocket/enums/ChallengeType.java
@@ -1,0 +1,6 @@
+package hyu.dayPocket.enums;
+
+public enum ChallengeType {
+
+    RECEIPT, TRADE, QUIZ
+}

--- a/src/main/java/hyu/dayPocket/enums/PointPaymentState.java
+++ b/src/main/java/hyu/dayPocket/enums/PointPaymentState.java
@@ -1,0 +1,9 @@
+package hyu.dayPocket.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum PointPaymentState {
+
+    WAITING, APPROVED, REJECTED
+}

--- a/src/main/java/hyu/dayPocket/repository/FiPointHistoryRepository.java
+++ b/src/main/java/hyu/dayPocket/repository/FiPointHistoryRepository.java
@@ -2,9 +2,14 @@ package hyu.dayPocket.repository;
 
 import hyu.dayPocket.domain.FiPointHistory;
 import hyu.dayPocket.domain.WithDrawalHistory;
+import hyu.dayPocket.enums.ChallengeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface FiPointHistoryRepository extends JpaRepository<FiPointHistory, Long> {
+
+    Optional<FiPointHistory> findTopByMemberIdAndChallengeOrderByDateDesc(Long memberId, ChallengeType type);
 }

--- a/src/main/java/hyu/dayPocket/repository/FiPointHistoryRepository.java
+++ b/src/main/java/hyu/dayPocket/repository/FiPointHistoryRepository.java
@@ -1,0 +1,10 @@
+package hyu.dayPocket.repository;
+
+import hyu.dayPocket.domain.FiPointHistory;
+import hyu.dayPocket.domain.WithDrawalHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FiPointHistoryRepository extends JpaRepository<FiPointHistory, Long> {
+}

--- a/src/main/java/hyu/dayPocket/repository/ReceiptRepository.java
+++ b/src/main/java/hyu/dayPocket/repository/ReceiptRepository.java
@@ -1,0 +1,8 @@
+package hyu.dayPocket.repository;
+
+import hyu.dayPocket.domain.Receipt;
+import hyu.dayPocket.domain.WithDrawalHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReceiptRepository extends JpaRepository<Receipt, Long> {
+}

--- a/src/main/java/hyu/dayPocket/repository/TradeRepository.java
+++ b/src/main/java/hyu/dayPocket/repository/TradeRepository.java
@@ -1,0 +1,8 @@
+package hyu.dayPocket.repository;
+
+import hyu.dayPocket.domain.Trade;
+import hyu.dayPocket.domain.WithDrawalHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TradeRepository extends JpaRepository<Trade, Long> {
+}

--- a/src/main/java/hyu/dayPocket/service/FiPointService.java
+++ b/src/main/java/hyu/dayPocket/service/FiPointService.java
@@ -1,0 +1,49 @@
+package hyu.dayPocket.service;
+
+import hyu.dayPocket.domain.FiPointHistory;
+import hyu.dayPocket.domain.Member;
+import hyu.dayPocket.domain.Receipt;
+import hyu.dayPocket.domain.Trade;
+import hyu.dayPocket.dto.PhotoRequestDto;
+import hyu.dayPocket.repository.FiPointHistoryRepository;
+import hyu.dayPocket.repository.MemberRepository;
+import hyu.dayPocket.repository.ReceiptRepository;
+import hyu.dayPocket.repository.TradeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class FiPointService {
+
+    private final MemberRepository memberRepository;
+    private final ReceiptRepository receiptRepository;
+    private final TradeRepository tradeRepository;
+    private final FiPointHistoryRepository fiPointHistoryRepository;
+
+
+    public void addFiPoint(PhotoRequestDto photoRequestDto){
+        Member member = memberRepository.findById(photoRequestDto.getMemberId())
+                .orElseThrow(() -> new RuntimeException("회원을 찾을 수 없습니다"));
+
+        if(photoRequestDto.getType().equals("RECEIPT")){
+            Receipt receipt = Receipt.receiptFrom(photoRequestDto.getLocation(), photoRequestDto.getItemName(),
+                    photoRequestDto.getAmount());
+            member.setFiPoint(member.getFiPoint()+100);
+            receiptRepository.save(receipt);
+            FiPointHistory fiPointHistory = FiPointHistory.fiPointHistoryFrom(member, 100, LocalDateTime.now());
+            fiPointHistoryRepository.save(fiPointHistory);
+            member.setFiScore(member.getFiScore()+1);
+        }else if(photoRequestDto.getType().equals("TRADE")){
+            Trade trade = Trade.tradeFrom(photoRequestDto.getAmount(), photoRequestDto.getItemName());
+            member.setFiPoint(member.getFiPoint()+500);
+            tradeRepository.save(trade);
+            FiPointHistory fiPointHistory = FiPointHistory.fiPointHistoryFrom(member, 500, LocalDateTime.now());
+            fiPointHistoryRepository.save(fiPointHistory);
+            member.setFiScore(member.getFiScore()+5);
+        }
+    }
+}

--- a/src/main/java/hyu/dayPocket/service/FiPointService.java
+++ b/src/main/java/hyu/dayPocket/service/FiPointService.java
@@ -5,18 +5,22 @@ import hyu.dayPocket.domain.Member;
 import hyu.dayPocket.domain.Receipt;
 import hyu.dayPocket.domain.Trade;
 import hyu.dayPocket.dto.PhotoRequestDto;
+import hyu.dayPocket.dto.StatusDto;
+import hyu.dayPocket.enums.ChallengeType;
+import hyu.dayPocket.enums.PointPaymentState;
 import hyu.dayPocket.repository.FiPointHistoryRepository;
 import hyu.dayPocket.repository.MemberRepository;
 import hyu.dayPocket.repository.ReceiptRepository;
 import hyu.dayPocket.repository.TradeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class FiPointService {
 
     private final MemberRepository memberRepository;
@@ -25,25 +29,46 @@ public class FiPointService {
     private final FiPointHistoryRepository fiPointHistoryRepository;
 
 
-    public void addFiPoint(PhotoRequestDto photoRequestDto){
+    public void updateFiPoint(PhotoRequestDto photoRequestDto){
         Member member = memberRepository.findById(photoRequestDto.getMemberId())
                 .orElseThrow(() -> new RuntimeException("회원을 찾을 수 없습니다"));
 
-        if(photoRequestDto.getType().equals("RECEIPT")){
-            Receipt receipt = Receipt.receiptFrom(photoRequestDto.getLocation(), photoRequestDto.getItemName(),
-                    photoRequestDto.getAmount());
-            member.setFiPoint(member.getFiPoint()+100);
-            receiptRepository.save(receipt);
-            FiPointHistory fiPointHistory = FiPointHistory.fiPointHistoryFrom(member, 100, LocalDateTime.now());
-            fiPointHistoryRepository.save(fiPointHistory);
-            member.setFiScore(member.getFiScore()+1);
-        }else if(photoRequestDto.getType().equals("TRADE")){
-            Trade trade = Trade.tradeFrom(photoRequestDto.getAmount(), photoRequestDto.getItemName());
-            member.setFiPoint(member.getFiPoint()+500);
-            tradeRepository.save(trade);
-            FiPointHistory fiPointHistory = FiPointHistory.fiPointHistoryFrom(member, 500, LocalDateTime.now());
-            fiPointHistoryRepository.save(fiPointHistory);
-            member.setFiScore(member.getFiScore()+5);
+        FiPointHistory fiPointHistory = fiPointHistoryRepository.findTopByMemberIdAndChallengeOrderByDateDesc(member.getId(), photoRequestDto.getType())
+                .orElseThrow(() -> new RuntimeException("fiPont로그를 찾을 수 없습니다"));
+
+        if(photoRequestDto.getState() == PointPaymentState.APPROVED){
+            if(fiPointHistory.getChallenge() == ChallengeType.RECEIPT){
+                Receipt receipt = Receipt.receiptFrom(photoRequestDto.getLocation(), photoRequestDto.getItemName(),
+                        photoRequestDto.getAmount());
+                member.setFiPoint(member.getFiPoint()+100);
+                receiptRepository.save(receipt);
+                member.setFiScore(member.getFiScore()+1);
+                fiPointHistory.updateFiPontHistory(100, LocalDateTime.now());
+            }else if(fiPointHistory.getChallenge() == ChallengeType.TRADE){
+                Trade trade = Trade.tradeFrom(photoRequestDto.getAmount(), photoRequestDto.getItemName());
+                member.setFiPoint(member.getFiPoint()+500);
+                member.setFiScore(member.getFiScore()+5);
+                tradeRepository.save(trade);
+                fiPointHistory.updateFiPontHistory(500, LocalDateTime.now());
+            }
+        }else{
+            fiPointHistory.updateStateRejected();
+        }
+    }
+
+
+    public StatusDto statusDto(Member member, ChallengeType type){
+        FiPointHistory fiPointHistory = fiPointHistoryRepository.findTopByMemberIdAndChallengeOrderByDateDesc(member.getId(), type)
+                .orElseThrow(() -> new RuntimeException("fiPont로그를 찾을 수 없습니다"));
+
+        PointPaymentState state = fiPointHistory.getState();
+
+        if(state == PointPaymentState.WAITING){
+            return new StatusDto(PointPaymentState.WAITING);
+        }else if(state == PointPaymentState.APPROVED){
+            return new StatusDto(PointPaymentState.APPROVED);
+        }else{
+            return new StatusDto(PointPaymentState.REJECTED);
         }
     }
 }

--- a/src/main/java/hyu/dayPocket/service/MemberService.java
+++ b/src/main/java/hyu/dayPocket/service/MemberService.java
@@ -119,6 +119,7 @@ public class MemberService {
                         .name(name)
                         .phoneNumber(phoneNumber)
                         .password(password)
+                        .fiScore(50L)
                         .build()
         );
     }

--- a/src/main/java/hyu/dayPocket/service/QuizService.java
+++ b/src/main/java/hyu/dayPocket/service/QuizService.java
@@ -4,6 +4,8 @@ import hyu.dayPocket.domain.FiPointHistory;
 import hyu.dayPocket.domain.Member;
 import hyu.dayPocket.dto.MemberChosenAnswer;
 import hyu.dayPocket.dto.QuizProvidingDto;
+import hyu.dayPocket.enums.ChallengeType;
+import hyu.dayPocket.enums.PointPaymentState;
 import hyu.dayPocket.repository.FiPointHistoryRepository;
 import hyu.dayPocket.repository.QuizRepository;
 import lombok.RequiredArgsConstructor;
@@ -51,7 +53,7 @@ public class QuizService {
 
         member.setFiPoint(member.getFiPoint() - 50 * correctAnswerCount);
         member.setFiScore(member.getFiScore()+ 50L * correctAnswerCount);
-        FiPointHistory fiPointHistory = FiPointHistory.fiPointHistoryFrom(member, 50 * correctAnswerCount, LocalDateTime.now());
+        FiPointHistory fiPointHistory = FiPointHistory.fiPointHistoryFrom(member, 50 * correctAnswerCount, PointPaymentState.APPROVED,  ChallengeType.QUIZ ,LocalDateTime.now());
         fiPointHistoryRepository.save(fiPointHistory);
         return correctAnswerCount;
     }

--- a/src/main/java/hyu/dayPocket/service/QuizService.java
+++ b/src/main/java/hyu/dayPocket/service/QuizService.java
@@ -1,13 +1,16 @@
 package hyu.dayPocket.service;
 
+import hyu.dayPocket.domain.FiPointHistory;
 import hyu.dayPocket.domain.Member;
 import hyu.dayPocket.dto.MemberChosenAnswer;
 import hyu.dayPocket.dto.QuizProvidingDto;
+import hyu.dayPocket.repository.FiPointHistoryRepository;
 import hyu.dayPocket.repository.QuizRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -17,6 +20,7 @@ import java.util.stream.Collectors;
 public class QuizService {
     private final QuizRepository quizRepository;
     private final MemberService memberService;
+    private final FiPointHistoryRepository fiPointHistoryRepository;
 
     public List<QuizProvidingDto> provideQuiz() {
         Long maxId = quizRepository.findMaxId();
@@ -46,6 +50,9 @@ public class QuizService {
                 .count();
 
         member.setFiPoint(member.getFiPoint() - 50 * correctAnswerCount);
+        member.setFiScore(member.getFiScore()+ 50L * correctAnswerCount);
+        FiPointHistory fiPointHistory = FiPointHistory.fiPointHistoryFrom(member, 50 * correctAnswerCount, LocalDateTime.now());
+        fiPointHistoryRepository.save(fiPointHistory);
         return correctAnswerCount;
     }
 }

--- a/src/main/resources/templates/admin/fiPointForm.html
+++ b/src/main/resources/templates/admin/fiPointForm.html
@@ -71,6 +71,14 @@
         </div>
     </div>
 
+    <div class="form-group">
+        <label>처리 상태:</label>
+        <select name="state">
+            <option value="APPROVED">승인</option>
+            <option value="REJECTED">반려</option>
+        </select>
+    </div>
+
     <button type="submit">포인트 지급</button>
 </form>
 

--- a/src/main/resources/templates/admin/fiPointForm.html
+++ b/src/main/resources/templates/admin/fiPointForm.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>FiPoint 관리자 페이지</title>
+    <style>
+        .form-group {
+            margin-bottom: 15px;
+        }
+
+        label {
+            display: inline-block;
+            width: 100px;
+        }
+
+        input, select {
+            padding: 5px;
+            width: 200px;
+        }
+    </style>
+</head>
+<body>
+<h2>하루지갑</h2>
+
+<form th:action="@{/admin/fiPointForm}" method="post">
+    <!-- 회원 선택 -->
+    <div class="form-group">
+        <label>회원 선택:</label>
+        <select name="memberId">
+            <option th:each="member : ${members}"
+                    th:value="${member.id}"
+                    th:text="${member.name + ' (' + member.phoneNumber + ')'}">
+            </option>
+        </select>
+    </div>
+
+    <!-- 인증 유형 선택 -->
+    <div class="form-group">
+        <label>사유:</label>
+        <select name="type" id="reason-select" onchange="toggleFields()">
+            <option value="RECEIPT">영수증 등록</option>
+            <option value="TRADE">중고거래 인증</option>
+        </select>
+    </div>
+
+    <!-- 영수증 영역 -->
+    <div id="receipt-fields">
+        <div class="form-group">
+            <label>장소:</label>
+            <input type="text" name="location" placeholder="예: 편의점">
+        </div>
+        <div class="form-group">
+            <label>구매 물건:</label>
+            <input type="text" name="itemName" id="receipt-item" placeholder="예: 커피">
+        </div>
+        <div class="form-group">
+            <label>금액:</label>
+            <input type="number" name="amount" id="receipt-amount" placeholder="예: 3500">
+        </div>
+    </div>
+
+    <!-- 중고거래 영역 -->
+    <div id="trade-fields" style="display: none;">
+        <div class="form-group">
+            <label>물건 이름:</label>
+            <input type="text" name="itemName" id="trade-item" placeholder="예: 노트북">
+        </div>
+        <div class="form-group">
+            <label>거래 금액:</label>
+            <input type="number" name="amount" id="trade-amount" placeholder="예: 50000">
+        </div>
+    </div>
+
+    <button type="submit">포인트 지급</button>
+</form>
+
+<script>
+    function toggleFields() {
+        const type = document.getElementById('reason-select').value;
+
+        const receiptFields = document.getElementById('receipt-fields');
+        const tradeFields = document.getElementById('trade-fields');
+
+        if (type === 'RECEIPT') {
+            receiptFields.style.display = 'block';
+            tradeFields.style.display = 'none';
+        } else {
+            receiptFields.style.display = 'none';
+            tradeFields.style.display = 'block';
+        }
+    }
+
+    // 페이지 로드 시 기본 값에 따라 필드 표시
+    window.addEventListener("DOMContentLoaded", toggleFields);
+</script>
+</body>
+</html>


### PR DESCRIPTION
## 📌 PR 제목

fiScore 초기설정 & 챌린지 수행시 fiPoint 및 fiScore를 업데이트
---

## 📝 변경사항
- 회원가입 시 fiScore 60도로 설정
- 영수증 , 중고거래 사진을 올리면 세부정보를 입력해서 저장하는 관리자페이지 추가(타임리프 사용)
- 챌린지를 수행할때마다 fiPointHistroy객체를 만들어서 챌린지 수행기록로그 저장
- 챌린지를 수행할때마다 fiPoint가 증가하고 증가한 fiPoint만큼 fiScore 증가
![스크린샷 2025-05-22 164747](https://github.com/user-attachments/assets/cf02e28f-9be4-4a0c-b069-2d716c329252)
![스크린샷 2025-05-22 164753](https://github.com/user-attachments/assets/402bdc6d-ea5e-47de-9dd7-74c6843e7287)

---

## 🔍 테스트 방법
- 직접 html폼에 정보를 입력해보기

---

## 💬 기타 참고사항
- 퀴즈같은 경우는 퀴즈 결과가 나오면서 바로 fiPoint와 fiScore가 업데이트 되지만
  다른 챌린지는 저희가 직접 수동으로 입력을 해야하기 때문에 사용자에게는 "현재 확인중입니다"라는 화면이 필요할거 같습니다
- 혹시 html폼이 잘 작성되었는지 확인 부탁드립니다. 