### PR TITLE
Fix: MemberRepository 집계함수 null값 처리

### DIFF
--- a/src/main/java/hyu/dayPocket/dto/AssetDto.java
+++ b/src/main/java/hyu/dayPocket/dto/AssetDto.java
@@ -10,12 +10,12 @@ public class AssetDto {
     private Long asset;
     private Integer targetReceiptFiPoint;
     private Integer receiptFiPoint;
-    private Double processPoint;
+    private int processPoint;
     private Integer leftPoint;
     private Integer fiPoint;
 
     public static AssetDto assetFrom(Long asset, Integer targetReceiptFiPoint, Integer receiptFiPoint,
-                                     Double processPoint, Integer leftPoint, Integer fiPoint) {
+                                     int processPoint, Integer leftPoint, Integer fiPoint) {
         return new AssetDto(asset, targetReceiptFiPoint, receiptFiPoint, processPoint, leftPoint, fiPoint);
 
     }

--- a/src/main/java/hyu/dayPocket/dto/DayMaxFiScoreDto.java
+++ b/src/main/java/hyu/dayPocket/dto/DayMaxFiScoreDto.java
@@ -11,7 +11,7 @@ public class DayMaxFiScoreDto {
     private String dayMaxFiScoreName;
     private Double dayAvgFiScore;
 
-    public static DayMaxFiScoreDto maxFiScoreFrom(Double dayMaxFiScore, String dayMaxFiScoreName, Long dayAvgFiScore) {
-        return new DayMaxFiScoreDto(dayAvgFiScore, dayMaxFiScoreName, dayMaxFiScore);
+    public static DayMaxFiScoreDto maxFiScoreFrom(Long dayMaxFiScore, String dayMaxFiScoreName, Double dayAvgFiScore) {
+        return new DayMaxFiScoreDto(dayMaxFiScore, dayMaxFiScoreName, dayAvgFiScore);
     }
 }

--- a/src/main/java/hyu/dayPocket/repository/MemberRepository.java
+++ b/src/main/java/hyu/dayPocket/repository/MemberRepository.java
@@ -24,7 +24,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     List<Object[]> findMonthFiPointSumGroupByMember(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
 
     @Query("select sum(f.fiPoint) from FiPointHistory f where f.date between :startDate and :endDate and f.member = :member")
-    Integer sumMonthFiPointByMember(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate, @Param("member") Member member);
+    Long sumMonthFiPointByMember(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate, @Param("member") Member member);
 
     @Query("select sum(f.fiPoint) from FiPointHistory f where f.member = :member")
     Long accumulateFiPointByMember(@Param("member") Member member);

--- a/src/main/java/hyu/dayPocket/service/MemberService.java
+++ b/src/main/java/hyu/dayPocket/service/MemberService.java
@@ -56,6 +56,11 @@ public class MemberService {
         LocalDateTime endOfMonth = currentMonth.atEndOfMonth().atTime(23, 59, 59);
         List<Object[]> monthMaxFiPointSumOrderByMember = memberRepository.findMonthFiPointSumGroupByMember(startOfMonth, endOfMonth);
         Double monthAvgFiPoint = getMonthAvgFiPoint(monthMaxFiPointSumOrderByMember);
+
+        if(monthMaxFiPointSumOrderByMember.isEmpty()){
+            return MonthMaxFiPointDto.maxFiPointFrom(monthAvgFiPoint, "*" ,0);
+        }
+
         Object[] topMember = monthMaxFiPointSumOrderByMember.get(0);
         Member member = (Member)topMember[0];
         Long memberFiPointLong = (Long) topMember[1];

--- a/src/main/java/hyu/dayPocket/service/MemberService.java
+++ b/src/main/java/hyu/dayPocket/service/MemberService.java
@@ -13,10 +13,12 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.text.DecimalFormat;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @Transactional(readOnly=true)
@@ -39,7 +41,8 @@ public class MemberService {
 
     public DayMaxFiScoreDto getDayMaxFiScoreDto(){
         List<Member> dayMaxFiScore = memberRepository.findDayMaxFiScoreMember();
-        Double avgFiScore = memberRepository.findAvgFiScore();
+        Double avg = memberRepository.findAvgFiScore();
+        Double avgFiScore = Optional.ofNullable(avg).orElse(0.0);
         String maxFiScoreName = dayMaxFiScore.get(0).getName();
         Long maxFiScore = dayMaxFiScore.get(0).getFiScore();
         DayMaxFiScoreDto dayMaxFiScoreDto = DayMaxFiScoreDto.maxFiScoreFrom(avgFiScore, getMemberNamePrivate(maxFiScoreName), maxFiScore);
@@ -55,7 +58,8 @@ public class MemberService {
         Double monthAvgFiPoint = getMonthAvgFiPoint(monthMaxFiPointSumOrderByMember);
         Object[] topMember = monthMaxFiPointSumOrderByMember.get(0);
         Member member = (Member)topMember[0];
-        Integer memberFiPoint = (Integer) topMember[1];
+        Long memberFiPointLong = (Long) topMember[1];
+        Integer memberFiPoint = (memberFiPointLong != null) ? memberFiPointLong.intValue() : 0;
         MonthMaxFiPointDto monthMaxFiPointDto = MonthMaxFiPointDto.maxFiPointFrom(monthAvgFiPoint, getMemberNamePrivate(member.getName()), memberFiPoint);
         return monthMaxFiPointDto;
     }
@@ -79,10 +83,12 @@ public class MemberService {
         Long asset = memberRepository.accumulateFiPointByMember(member);
         Integer targetReceiptFiPoint = member.getTargetReceiptfiPoint();
         Integer receiptFiPoint = member.getReceiptfiPoint();
-        Double processPoint  = ((double) receiptFiPoint / (double) targetReceiptFiPoint  * 100);
+        double processPoint = ((double) receiptFiPoint / (double) targetReceiptFiPoint) * 100;
+        int roundedProcessPoint = (int) Math.round(processPoint);
         Integer leftPoint = targetReceiptFiPoint - receiptFiPoint;
-        Integer fiPoint = memberRepository.sumMonthFiPointByMember(startOfMonth, endOfMonth, member);
-        AssetDto assetDto = AssetDto.assetFrom(asset, targetReceiptFiPoint, receiptFiPoint, processPoint, leftPoint, fiPoint);
+        Long fiPointLong = memberRepository.sumMonthFiPointByMember(startOfMonth, endOfMonth, member);
+        Integer fiPoint = fiPointLong != null ? fiPointLong.intValue() : 0;
+        AssetDto assetDto = AssetDto.assetFrom(asset, targetReceiptFiPoint, receiptFiPoint, roundedProcessPoint, leftPoint, fiPoint);
         return assetDto;
     }
 
@@ -125,6 +131,9 @@ public class MemberService {
                         .password(passwordEncoder.encode(password))
                         .fiScore(50L)
                         .fiPoint(0)
+                        .asset(0L)
+                        .targetReceiptfiPoint(0)
+                        .receiptfiPoint(0)
                         .build()
         );
     }
@@ -161,6 +170,8 @@ public class MemberService {
             return name.substring(0, middle) + "*" + name.substring(middle + 1);
         }
     }
+
+
 
 
 


### PR DESCRIPTION
## 📌 PR 제목
MemberRepository 집계함수 null값 처리

---

## 📝 변경사항
- memberRepository에 사용하는 sum, avg함수에 값이 없으면 Null값이 반환 되어서 기본 값을 0으로 설정했습니다
- sum함수의 반환값이 Long인데 Integer로 바로 변환할 수 없기 때문에 그 부분도 수정했습니다
- AssetDto부분에서 목표금액 퍼센트를 확인할 수 있는 processPoint를 int로 변경했습니다

---

## 🔍 테스트 방법
- 

---

## 💬 기타 참고사항
- 