### PR TITLE
Fix: targetReceiptFiPoint db 반영 오류 수정

### DIFF
--- a/src/main/java/hyu/dayPocket/service/ReceiptService.java
+++ b/src/main/java/hyu/dayPocket/service/ReceiptService.java
@@ -3,6 +3,7 @@ package hyu.dayPocket.service;
 import hyu.dayPocket.domain.Member;
 import hyu.dayPocket.dto.TargetReceiptFiPointDto;
 import hyu.dayPocket.repository.MemberRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,8 +16,8 @@ public class ReceiptService {
 
     @Transactional
     public void setTargetReceiptFiPoint(Member member, Integer targetReceiptFiPoint) {
-        TargetReceiptFiPointDto dto = TargetReceiptFiPointDto.targetReceiptFiPointFrom(targetReceiptFiPoint);
-        member.updateTargetReceiptFiPoint(dto.getTargetReceiptFiPoint());
+        Member loginMember = memberRepository.findById(member.getId()).orElseThrow(() -> new EntityNotFoundException("Member is not found"));
+        loginMember.updateTargetReceiptFiPoint(targetReceiptFiPoint);
     }
 
 


### PR DESCRIPTION
## 📌 PR 제목
targetReceiptFiPoint db 반영 오류 수정

---

## 📝 변경사항
- 서비스 계층에서 memberId를 한번더 조회후 값을 변경하는 방식으로 수정했습니다

---

## 🔍 테스트 방법
-

---

## 💬 기타 참고사항
- @AuthenticationPrincipal로 가져온 멤버 객체는 인증 과정이 끝나고 준영속 상태가 되기 때문에 setTargetReceiptFiPoint메소드에서 트랜잭션을 걸어도 jpa에서 변경을 감지 못해서 db에 반영이 안되는거 같습니다. 그래서 setTargetReceiptFiPoint메소드의 트랜잭션 내에서 한 번 더 멤버를 조회해서 영속 상태로 만든 다음에 멤버의 필드를 변경하는 방법으로 변경했습니다 