### PR TITLE
Fix: main/home sum 오류 수정

### DIFF
--- a/src/main/java/hyu/dayPocket/service/MemberService.java
+++ b/src/main/java/hyu/dayPocket/service/MemberService.java
@@ -61,11 +61,11 @@ public class MemberService {
         LocalDateTime startOfMonth = currentMonth.atDay(1).atStartOfDay();;
         LocalDateTime endOfMonth = currentMonth.atEndOfMonth().atTime(23, 59, 59);
         List<Object[]> monthMaxFiPointSumOrderByMember = memberRepository.findMonthFiPointSumGroupByMember(startOfMonth, endOfMonth);
-        Double monthAvgFiPoint = getMonthAvgFiPoint(monthMaxFiPointSumOrderByMember);
 
         if(monthMaxFiPointSumOrderByMember.isEmpty()){
-            return MonthMaxFiPointDto.maxFiPointFrom(monthAvgFiPoint, "*" ,0);
+            return MonthMaxFiPointDto.maxFiPointFrom(0.0, "*" ,0);
         }
+        Double monthAvgFiPoint = getMonthAvgFiPoint(monthMaxFiPointSumOrderByMember);
 
         Object[] topMember = monthMaxFiPointSumOrderByMember.get(0);
         Member member = (Member)topMember[0];


### PR DESCRIPTION
## 📌 PR 제목
Fix: main/home sum 오류 수정
---

## 📝 변경사항
- monthMaxFiPointSumOrderByMember의 empty체크와 monthAvgFiPoint를 구하는 로직의 순서를 바꾸어 null을 방지했습니다

---

## 🔍 테스트 방법
- 

---

## 💬 기타 참고사항
- 